### PR TITLE
Fix stuck txs due to nonce gap

### DIFF
--- a/core/src/lib/scripts/spam.ts
+++ b/core/src/lib/scripts/spam.ts
@@ -72,6 +72,7 @@ export const spamLoop = async (mevFlood: MevFlood, wallet: Wallet, params: {
         if (now() - lastBlockSampledAt > 12000) {
             targetBlockNumber += 1
             lastBlockSampledAt = now()
+            virtualNonce = await wallet.getTransactionCount()
         }
     }
 }


### PR DESCRIPTION
mev-flood does not calculate the tx nonce correctly if a tx failed and will keep incrementing the nonce.