### PR TITLE
update `cli` so `flood.liquid()` uses correct `wethMintAmount` flag

### DIFF
--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -30,8 +30,8 @@ export default class Init extends Command {
     const userWallet = new Wallet(flags.userKey, provider)
     this.log(`connected to ${flags.rpcUrl} with wallet ${wallet.address}`)
     const deployment = await flood.liquid({
-      wethMintAmountAdmin: flags.wethMintAmountOwner,
-      wethMintAmountUser: flags.wethMintAmountUser,
+      wethMintAmountAdmin: flags.wethMintAmount,
+      wethMintAmountUser: flags.wethMintAmount,
     }, userWallet)
     await deployment.deployToMempool()
     this.log('liquidity deployed via mempool')


### PR DESCRIPTION
When calling `flood.liquid()` The `cli` passes`flags.wethMintAmountOwner` and `flags.wethMintAmountUser` which don't exist.

The correct flag to use is `flags.wethMintAmount` which is set with `--wethMintAmount` (or `-a`)